### PR TITLE
アクション実行を1日ごとに設定 / 実行条件を更新した

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: Test
 
-on: [push]
+on:
+  schedule:
+    # 毎日 11:00 (JST) に処理を実行する。
+    # UTC 02:00 -> JST 11:00
+    - cron: '0 2 * * *'
 
 jobs:
   build:

--- a/src/func.py
+++ b/src/func.py
@@ -1,6 +1,7 @@
 import re
 import requests
 from typing import List, Union
+from datetime import datetime
 
 """
 split grep_result
@@ -23,6 +24,7 @@ def split_grep_result(TARGET: str, grep_result: str) -> List[Union[str, int, str
 
 """
 ISSUE が CLOSE されているかの確認
+- 24時間以内にCLOSEされていたらPR作成を行う
 """
 def is_issue_closed(owner: str, repo: str, number: str) -> bool:
     response = requests.get(f'https://api.github.com/repos/{owner}/{repo}/issues/{number}')
@@ -32,9 +34,14 @@ def is_issue_closed(owner: str, repo: str, number: str) -> bool:
     response = response.json()
     state = response['state']
 
-    # closed_at = response['closed_at']
+    if state != 'closed': return False
+
+    closed_at = response['closed_at']
+    datetime_closed_at = datetime.strptime(closed_at, "%Y-%m-%dT%H:%M:%SZ")
+    now = datetime.now()
     
-    return state == 'closed'
+    # ISSUE が closed かつ closed_at との時間差が 1日以内であれば TRUE
+    return (now - datetime_closed_at).days < 1
 
 
 """

--- a/src/main.py
+++ b/src/main.py
@@ -17,7 +17,7 @@ def main():
     notify の条件確認
     """
     if not is_issue_closed(owner=target_info[0], repo=target_info[1], number=target_info[2]):
-        print("this issue is still opened")
+        print("this issue is 'still opened' or 'closed at more than a day ago'.")
         return
 
     """


### PR DESCRIPTION
## 概要
アクションの実行を 毎朝11時に設定し，
ISSUE が 24時間以内に Close されたかを実行条件とした．

## 詳細（主に技術的変更点）

## 使い方・確認方法（設定変更やコマンドが必要ならばそれも書く）
* 明日の11時に実行されるかの確認
* テストを作成

## 保留した項目・TODOリスト
* release検知用の処理を追加
* ~~リンクを元にissueがcloseされているか確認~~
* ~~ファイルを変更してPRを作成~~
* ~~既にPRを作成しているか確認~~
  * 1日前と比較すれば良い？

## その他（レビューで見てもらいたい点、不安な点、参考URLなど）
