### PR TITLE
バグ修正: not response.ok

### DIFF
--- a/src/func.py
+++ b/src/func.py
@@ -34,7 +34,7 @@ ISSUE が CLOSE されているかの確認
 def is_issue_closed(owner: str, repo: str, number: str) -> bool:
     response = requests.get(f'https://api.github.com/repos/{owner}/{repo}/issues/{number}')
 
-    if response.ok: return False
+    if not response.ok: return False
 
     response = response.json()
     state = response['state']
@@ -55,7 +55,7 @@ def is_issue_closed(owner: str, repo: str, number: str) -> bool:
 def is_new_version_released(owner: str, repo: str) -> bool:
     response = requests.get(f'https://api.github.com/repos/{owner}/{repo}/releases/latest')
 
-    if response.ok: return False
+    if not response.ok: return False
 
     published_at = response['published_at']
     datetime_published_at = datetime.strptime(published_at, "%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
## 概要
* GitHub API のレスポンスが成功したときに `return: False` をしていたので修正...

```diff
- if response.ok: return False
+ if not response.ok: return False
```

## 詳細（主に技術的変更点）

## 使い方・確認方法（設定変更やコマンドが必要ならばそれも書く）

## 保留した項目・TODOリスト

## その他（レビューで見てもらいたい点、不安な点、参考URLなど）
